### PR TITLE
implement better client behavior to generate/cleanup tokens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
             "name": "Mocha Tests",
             "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
             "args": [
-                "${workspaceRoot}/test"
+                "${workspaceRoot}/test/*.js", "${workspaceRoot}/test/cleanup/*.js"
             ],
             "internalConsoleOptions": "openOnSessionStart"
         },
@@ -199,6 +199,21 @@
             ],
             "internalConsoleOptions": "openOnSessionStart"
         },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Cleanup User Tokens (post-testing)",
+            "env": {
+                "DEBUG": "true"
+            },
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/babel-node.cmd",
+            "sourceMaps": true,
+            "args": [
+                "${workspaceRoot}/test/cleanup/runCleanup_spec.js"
+            ],
+            "internalConsoleOptions": "openOnSessionStart"
+        },        
         {
             "type": "node",
             "request": "launch",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A sandbox project including samples and workflows with the Fortify Software Security Center (SSC) REST API",
   "main": "index.js",
   "scripts": {
-    "all": "mocha test",
+    "all": "mocha test/*.js test/cleanup/runCleanup_spec.js",
     "apiInfo": "mocha test/apiInfo_spec.js",
     "assignUserToVersions": "mocha test/assignUserToVersions_spec.js",
     "assignAppVersionToAuthEntities": "mocha test/assignAppVersionToAuthEntities_spec.js",
@@ -16,7 +16,8 @@
     "getVersionIssues":"mocha test/issues_spec.js",
     "predict": "mocha test/auditAssistantBatchPredict_spec.js",
     "train": "mocha test/auditAssistantBatchTraining_spec.js",
-    "uploadFPR": "mocha test/fprUpload_spec.js"
+    "uploadFPR": "mocha test/fprUpload_spec.js",
+    "runCleanup": "mocha test/cleanup/runCleanup_spec.js"
   },
   "repository": {
     "type": "git",

--- a/src/commonTestsUtils.js
+++ b/src/commonTestsUtils.js
@@ -54,6 +54,22 @@ class CommonTestUtils {
         });
     }
     
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method if you plan on re-using a long-lived token for your authentication.
+     */
+    doCleanup(done, myRestClient) {
+        // assumes initialized restClient
+        let client; 
+        if (!myRestClient) {
+            myRestClient = restClient;
+        }
+        myRestClient.clearTokensOfUser().then(() => {
+            done()
+        }).catch((err) => { 
+            done(err) 
+        });
+    }
+
     /**
      * does a batch submission of API calls in chunks.
      * Follows this algorithm:

--- a/src/restClient.js
+++ b/src/restClient.js
@@ -101,7 +101,7 @@ export default class restClient {
                 async.waterfall([
                     function getToken(callback) {
                         /* do not create token again if we already have one. 
-                         * In general, for automations either use a short-lived (1day) token such as "UnifiedLoginToken"
+                         * In general, for automations either use a short-lived (<1day) token such as "UnifiedLoginToken"
                          * or preferably, use a long-lived token such as "AnalysisUploadToken"/"JenkinsToken" (lifetime is several months)
                          * and retrieve it from persistent storage. DO NOT create new long-lived tokens for every run!!  */
                         if (global.myToken) { 

--- a/src/restClient.js
+++ b/src/restClient.js
@@ -104,18 +104,14 @@ export default class restClient {
                          * In general, for automations either use a short-lived (<1day) token such as "UnifiedLoginToken"
                          * or preferably, use a long-lived token such as "AnalysisUploadToken"/"JenkinsToken" (lifetime is several months)
                          * and retrieve it from persistent storage. DO NOT create new long-lived tokens for every run!!  */
-                        if (global.myToken) { 
-                            console.log("Already have login token, skipping login token creation...");   
-                            callback(null, global.myToken);
-                        } else {
-                            console.log("Creating new login token");
-                            restClient.generateToken("UnifiedLoginToken")
-                                .then((token) => {
-                                    callback(null, token);
-                                }).catch((error) => {
-                                    callback(error);
-                                });
-                        }
+                        
+                        //console.log("Creating new login token");
+                        restClient.generateToken("UnifiedLoginToken")
+                            .then((token) => {
+                               callback(null, token);
+                            }).catch((error) => {
+                                callback(error);
+                            });                        
                     },
                     function heartbeat(token, callback) {
                         api["feature-controller"].listFeature({}, getClientAuthTokenObj(token)).then((features) => {
@@ -128,8 +124,7 @@ export default class restClient {
                     if (err) {
                         reject(err);
                     } else {
-                        that.token = token; //save token
-                        global.myToken = token; 
+                        that.token = token; //save token                    
                         resolve("success");
                     }
                 });
@@ -497,6 +492,7 @@ export default class restClient {
     }
     /* 
     * clears all tokens belonging to test user
+    * **Do not use this method if you are using a long-lived token for your authentication!**
     * (In the 17.20 release, clearing an individual token by value is not supported by the "auth-token-controller" endpoint.
     * To delete individual tokens, the 'fortifyclient' tool can be used.) 
     */

--- a/src/restClient.js
+++ b/src/restClient.js
@@ -100,12 +100,22 @@ export default class restClient {
                 that.api = api;
                 async.waterfall([
                     function getToken(callback) {
-                        restClient.generateToken("UnifiedLoginToken")
-                            .then((token) => {
-                                callback(null, token);
-                            }).catch((error) => {
-                                callback(error);
-                            });
+                        /* do not create token again if we already have one. 
+                         * In general, for automations either use a short-lived (1day) token such as "UnifiedLoginToken"
+                         * or preferably, use a long-lived token such as "AnalysisUploadToken"/"JenkinsToken" (lifetime is several months)
+                         * and retrieve it from persistent storage. DO NOT create new long-lived tokens for every run!!  */
+                        if (global.myToken) { 
+                            console.log("Already have login token, skipping login token creation...");   
+                            callback(null, global.myToken);
+                        } else {
+                            console.log("Creating new login token");
+                            restClient.generateToken("UnifiedLoginToken")
+                                .then((token) => {
+                                    callback(null, token);
+                                }).catch((error) => {
+                                    callback(error);
+                                });
+                        }
                     },
                     function heartbeat(token, callback) {
                         api["feature-controller"].listFeature({}, getClientAuthTokenObj(token)).then((features) => {
@@ -119,6 +129,7 @@ export default class restClient {
                         reject(err);
                     } else {
                         that.token = token; //save token
+                        global.myToken = token; 
                         resolve("success");
                     }
                 });
@@ -483,6 +494,29 @@ export default class restClient {
             });
         });
 
+    }
+    /* 
+    * clears all tokens belonging to test user
+    * (In the 17.20 release, clearing an individual token by value is not supported by the "auth-token-controller" endpoint.
+    * To delete individual tokens, the 'fortifyclient' tool can be used.) 
+    */
+    clearTokensOfUser() {
+        const restClient = this;
+        return new Promise((resolve, reject) => {
+            const auth = 'Basic ' + new Buffer(config.user + ':' + config.password).toString('base64');
+
+            restClient.api["auth-token-controller"].multiDeleteAuthToken({all:true}, {
+                responseContentType: 'application/json',
+                clientAuthorizations: {
+                    "Basic": new Swagger.PasswordAuthorization(config.user, config.password)
+                }
+            }).then((data) => {
+                //got it so pass along
+                resolve(data.obj.data); // will be 'true' but we don't really care about return value.
+            }).catch((error) => {
+                reject(error);
+            });
+        });
     }
     /**
      * uploads a single FPR to a version based on ID

--- a/test/apiInfo_spec.js
+++ b/test/apiInfo_spec.js
@@ -38,8 +38,11 @@ describe('api info', function () {
     });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. 
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
 
   /**

--- a/test/assignAppVersionToAuthEntities_spec.js
+++ b/test/assignAppVersionToAuthEntities_spec.js
@@ -36,8 +36,11 @@ describe('assign authenticated entities (users and ldap entities) to an  appvers
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
   
   const pvId = config.sampleSecondaryVersionId;

--- a/test/assignUserToVersions_spec.js
+++ b/test/assignUserToVersions_spec.js
@@ -38,9 +38,13 @@ describe('assign a user to one or more project versions', function () {
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
+
   /**
    * Assign given user to one or more project versions
    */

--- a/test/auditAssistantBatchPredict_spec.js
+++ b/test/auditAssistantBatchPredict_spec.js
@@ -16,7 +16,6 @@ const CommonTestUtils =  require('../src/commonTestsUtils');
 
 const commonTestsUtils = new CommonTestUtils();
 
-
 describe('batch send for predictions audit assistant', function () {
 
   before(function () {
@@ -26,8 +25,11 @@ describe('batch send for predictions audit assistant', function () {
     }
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done);
   });
 
   it('validates all properties exist', function (done) {

--- a/test/auditAssistantBatchTraining_spec.js
+++ b/test/auditAssistantBatchTraining_spec.js
@@ -16,7 +16,6 @@ const CommonTestUtils =  require('../src/commonTestsUtils');
 
 const commonTestsUtils = new CommonTestUtils();
 
-
 describe('batch predicts audit assistant', function () {
 
   before(function () {
@@ -26,8 +25,11 @@ describe('batch predicts audit assistant', function () {
     }
   });
 
-  after(function () {
-
+  after(function (done) {
+     /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done);
   });
 
   it('validates all properties exist', function (done) {

--- a/test/cleanup/runCleanup_spec.js
+++ b/test/cleanup/runCleanup_spec.js
@@ -1,0 +1,57 @@
+/**
+ * (c) Copyright [yyyy] EntIT Software LLC
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*  http://www.apache.org/licenses/LICENSE-2.0
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+const assert = require('assert');
+const expect = require('chai').expect;
+const chalk = require('chalk')
+const CommonTestUtils = require('../../src/commonTestsUtils');
+const commonTestsUtils = new CommonTestUtils();
+import RestClient from '../../src/restClient';
+const restClient = new RestClient();
+
+/**
+ * perform any global cleanups after the test sequence. 
+ * If you run any tests individually, you may also want to run this test manually to cleanup. 
+ */
+describe('run last and clean up after the full sequence of tests', function () {
+
+  before(function (done) {
+    //override NodeJS security for SSC (unprotected)
+    if (process.env.DisableSSLSecurity) {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    }
+    /**
+     * initialize and authenticate
+     */
+    restClient.initialize().then(() => {
+      done()
+    }).catch((err) => { done(err) });
+  });
+
+  after(function () {
+
+  });
+
+  /**
+   * clear tokens
+   */
+  it('clears all tokens owned by the test user', function (done) {
+    
+    restClient.clearTokensOfUser().then((status) => {
+      console.log(chalk.green("successfully cleared all tokens owned by test user "));
+      done();
+    }).catch((err) => {
+      console.log(chalk.red("error clearing tokens owned by test user"), err)
+      done(err);
+    });
+  });
+});

--- a/test/createLocalUserAndAssignToVersion_spec.js
+++ b/test/createLocalUserAndAssignToVersion_spec.js
@@ -38,8 +38,11 @@ describe('create a new local user and assign to a project version', function () 
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
   /**
    * create local user

--- a/test/createVersion_spec.js
+++ b/test/createVersion_spec.js
@@ -36,8 +36,11 @@ describe('creates an Application version (a.k.a Project version)', function () {
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
   
   /**

--- a/test/fprDownload_spec.js
+++ b/test/fprDownload_spec.js
@@ -16,6 +16,8 @@ const chalk = require('chalk');
 import configLoader from '../config';
 import RestClient from '../src/restClient';
 const restClient = new RestClient();
+const CommonTestUtils = require('../src/commonTestsUtils');
+const commonTestsUtils = new CommonTestUtils();
 const config = configLoader.loadEnv();
 
 
@@ -37,9 +39,13 @@ describe('downloads an FPR and tracks processsing to completion', function () {
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
+
   let artifactJobid, jobEntity = undefined;
   /**
    * downloads an FPR

--- a/test/fprUpload_spec.js
+++ b/test/fprUpload_spec.js
@@ -39,9 +39,13 @@ describe('uploads and FPR and tracks processsing to completion', function () {
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
+
   let artifactJobid, jobEntity = undefined;
   /**
    * create a version

--- a/test/generateReport_spec.js
+++ b/test/generateReport_spec.js
@@ -38,9 +38,13 @@ describe('generate a report and tracks status to completion', function () {
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
+
   let savedReportEntity = undefined;
   /**
    * generate report

--- a/test/issues_spec.js
+++ b/test/issues_spec.js
@@ -39,8 +39,11 @@ describe('Explore issue-of-project-version-controller', function () {
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
 
   it('get all issues with batching', function (done) {

--- a/test/token_spec.js
+++ b/test/token_spec.js
@@ -44,8 +44,8 @@ describe('generate tokens by type', function () {
    * create a version
    */
   it('generates a token ', function (done) {
-    //generate a unifiedLoginToken by default or look in env for override
-    let type = 'UnifiedLoginToken';
+    //generate a CloudOneTimeJobToken by default or look in env for override
+    let type = 'CloudOneTimeJobToken';
     //AnalysisDownloadToken, AnalysisUploadToken, AuditToken, UploadFileTransferToken, DownloadFileTransferToken, ReportFileTransferToken, CloudCtrlToken,
     //CloudOneTimeJobToken, WIESystemToken, WIEUserToken, UnifiedLoginToken, ReportToken, PurgeProjectVersionToken
     if (process.env.FORTIFY_TOKEN_TYPE) {

--- a/test/token_spec.js
+++ b/test/token_spec.js
@@ -36,8 +36,11 @@ describe('generate tokens by type', function () {
     }).catch((err) => { done(err) });
   });
 
-  after(function () {
-
+  after(function (done) {
+    /* Perform any cleanups. currently clears all tokens of test user.
+     * Do not call this method below if you plan on re-using a long-lived token for your authentication.
+     */
+    commonTestsUtils.doCleanup(done, restClient);
   });
 
   /**


### PR DESCRIPTION
Took a while to get back some context to work on this codebase! but got some changes done.
-the client now only creates one ULT token for the whole sequence instead of one per test file.
(actually, the recommended way for a customer automation would be to use long-lived tokens like AnalysisUploadToken and JenkinsToken rather than ULT. But since here we are dealing with a test suite, using the ULT works better for a daily use throw-away rather than persisting to a file.)
-added a new method to exercise the token deletion endpoint in 17.2 (deletes all tokens by user).
-added a new cleanup file to run at the end of the test sequence.

(squash merge preferred)