### PR TITLE
Fix updateCustomTagsOfVersion and createCustomTag tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 .gradle
 npm*.log
 *.pdf
-.env
+.env*
 yarn*.log
 yarn.lock
 fpr/*

--- a/config.js
+++ b/config.js
@@ -15,8 +15,8 @@ const config = {
     batchSize: 2, //rest call parrallel batch size - how many version to call in parallel in one batch (batches executed sequentually)
     sampleFPR: '/fpr/Log1.3_splc-20.1.0.fpr',
     sampleAppId: 1,
-    sampleVersionId: 2,//sample app version id
-    sampleCustomTagId: 11,//sample custom tag id
+    sampleVersionId: 1,//sample app version id
+    sampleCustomTagId: -1,//sample custom tag id, or -1 to create a new custom tag before adding
     sampleSecondaryVersionId: 4,
     sampleArtifactId: 10, // sample fpr id
     downloadFolder: "/downloads", //relative to root project, wil be created if non existant

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "assignAppVersionToAuthEntities": "mocha test/assignAppVersionToAuthEntities_spec.js",
     "createLocalUserAndAssignToVersion": "mocha test/createLocalUserAndAssignToVersion_spec.js",
     "createVersion": "mocha test/createVersion_spec.js",
+    "createCustomTag": "mocha test/createCustomTag_spec.js",
     "generateToken": "mocha test/token_spec.js",
     "generateReport": "mocha test/generateReport_spec.js",
     "downloadFPR": "mocha test/fprDownload_spec.js",
@@ -20,8 +21,7 @@
     "train": "mocha test/auditAssistantBatchTraining_spec.js",
     "uploadFPR": "mocha test/fprUpload_spec.js",
     "runCleanup": "mocha test/cleanup/runCleanup_spec.js",
-    "updateCustomTagsOfVersion": "mocha test/updateCustomTagsOfVersion_spec.js",
-    "createCustomTag": "mocha test/createCustomTag_spec.js"
+    "updateCustomTagsOfVersion": "mocha test/updateCustomTagsOfVersion_spec.js"
   },
   "repository": {
     "type": "git",

--- a/test/createCustomTag_spec.js
+++ b/test/createCustomTag_spec.js
@@ -49,8 +49,8 @@ describe('creates a Custom Tag ', function () {
   it('creates a custom tag', function (done) {
     const customTag = config.sampleCustomTag;
     customTag.name = 'JS-Sandbox ' + Math.floor(Math.random() * 1000);
-    restClient.createCustomTag(customTag).then((result) => {
-      console.log(chalk.green("successfully created custom tag " + customTag.name + " with id " + customTag.id));
+    restClient.createCustomTag(customTag).then((newCustomTag) => {
+      console.log(chalk.green("successfully created custom tag " + newCustomTag.name + " with id " + newCustomTag.id));
       done();
     }).catch((err) => {
       console.log(chalk.red("error creating version "), err)

--- a/test/updateCustomTagsOfVersion_spec.js
+++ b/test/updateCustomTagsOfVersion_spec.js
@@ -61,15 +61,26 @@ describe('add an existing custom tag to project version', function () {
     });
   });
 
-  it('get the specific custom tag that we want to add and append to final list', function (done) {
-    restClient.getCustomTag([config.sampleCustomTagId]).then((response) => {
-      customTags.push(response.obj.data);
-      console.log(chalk.green(`IDs of custom tag list with new appended element: ` + customTags.map(elem => elem.id).join(", ")));
-      done();
-    }).catch((err) => {
-      console.log(chalk.red("error appending the selected custom tag to the list"), err)
-      done(err);
-    });
+  it('get the specific custom tag that we want to add and append to final list or create a new custom tag', function (done) {
+    let customTagId = config.sampleCustomTagId;
+    if (config.sampleCustomTagId < 0) {
+      const customTag = config.sampleCustomTag;
+      customTag.name = 'Custom tag for version id ' + config.sampleVersionId + ' ' + Math.floor(Math.random() * 1000);
+      restClient.createCustomTag(customTag).then((newCustomTag) => {
+        console.log(chalk.green("successfully created custom tag " + newCustomTag.name + " with id " + newCustomTag.id));
+        restClient.getCustomTag([newCustomTag.id]).then((response) => {
+          customTags.push(response.obj.data);
+          console.log(chalk.green(`IDs of custom tag list with new appended element: ` + customTags.map(elem => elem.id).join(", ")));
+          done();
+        }).catch((err) => {
+          console.log(chalk.red("error appending the selected custom tag to the list"), err)
+          done(err);
+        });
+      }).catch((err) => {
+        console.log(chalk.red("error creating version "), err)
+        done(err);
+      });
+    }
   });
 
   it('update the list of custom tags', function (done) {


### PR DESCRIPTION
Provide option to create a new custom tag to prevent test failures due to invalid custom tag id.